### PR TITLE
Fix kernel install command

### DIFF
--- a/OpenSARlab_supplements/Jupyter_Conda_Environments.ipynb
+++ b/OpenSARlab_supplements/Jupyter_Conda_Environments.ipynb
@@ -117,7 +117,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<font face=\"Calibri\" size=\"3\"><b>Enter all packages to install, in addition to the required notebook=6.1.4.</b>\n",
+    "<font face=\"Calibri\" size=\"3\"><b>Enter all packages to install, in addition to the required \"jupyter\" package.</b>\n",
     "    <br>\n",
     "Packages can include explicit version declarations (pyproj=2.6.0) or not (pyproj).\n",
     "Enter packages one at a time or in a space separated list (gdal pyproj numpy=1.19.2 matplotlib)</font>"

--- a/OpenSARlab_supplements/Jupyter_Conda_Environments.ipynb
+++ b/OpenSARlab_supplements/Jupyter_Conda_Environments.ipynb
@@ -187,7 +187,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "kernel_cmd = f\"{env_dir}/bin/python -m ipykernel install --prefix=/home/jovyan/.local --name {env_name}\"\n",
+    "kernel_cmd = f\"{env_dir}/bin/python -m ipykernel install --user --name {env_name}\"\n",
     "print(kernel_cmd)"
    ]
   },

--- a/OpenSARlab_supplements/Jupyter_Conda_Environments.ipynb
+++ b/OpenSARlab_supplements/Jupyter_Conda_Environments.ipynb
@@ -187,7 +187,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "kernel_cmd = f\"{env_dir}/bin/python -m ipykernel install --prefix=/{env_dir} --name {env_name}\"\n",
+    "kernel_cmd = f\"{env_dir}/bin/python -m ipykernel install --prefix=/home/jovyan/.local --name {env_name}\"\n",
     "print(kernel_cmd)"
    ]
   },


### PR DESCRIPTION
As currently written in the notebook, the kernel install command gives you this warning:
```
WARNING | Installing to ..., which is not in ['/home/jovyan/.local/share/jupyter/kernels', '/opt/conda/share/jupyter/kernels', '/usr/local/share/jupyter/kernels', '/usr/share/jupyter/kernels', '/home/jovyan/.ipython/kernels']. The kernelspec may not be found.
```

`--prefix` would need to point to `~/.local` as kernel install location is `${PREFIX}/share/jupyter/kernels`. However, it's easier to use the `--user` command instead of specifying `--prefix`. 

Docs: https://ipython.readthedocs.io/en/stable/install/kernel_install.html